### PR TITLE
Index plugin on Gatsby's website

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "repository": "https://github.com/jlengstorf/gatsby-remark-numbered-footnotes.git",
   "author": "Jason Lengstorf <jason@lengstorf.com> (https://lengstorf.com)",
   "license": "MIT",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin"
+  ],
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__"
   },


### PR DESCRIPTION
Community plugins needs the "gatsby-plugin" keyword to show up in the search. 

see https://github.com/gatsbyjs/gatsby/issues/4394#issuecomment-371659310